### PR TITLE
Add logic to include category, payMethod on GET ~/account-history

### DIFF
--- a/server/routes/account-history.ts
+++ b/server/routes/account-history.ts
@@ -22,7 +22,7 @@ router.get('/', checkToken(), async (req: any, res) => {
     const accountHistory = await db.accountHistory.findMany({
       where: { ...opt, userId: req.id },
       include: {
-        category: { select: { name: true } },
+        category: { select: { id: true, name: true } },
         payMethod: { select: { id: true, name: true } },
       },
     });

--- a/server/routes/account-history.ts
+++ b/server/routes/account-history.ts
@@ -13,6 +13,27 @@ type FilterOption = {
 };
 
 /**
+ * 필터에 맞는 accountHistory를 반환합니다.
+ */
+router.get('/', checkToken(), async (req: any, res) => {
+  try {
+    const opt = generateFilter(req.query);
+
+    const accountHistory = await db.accountHistory.findMany({
+      where: { ...opt, userId: req.id },
+      include: {
+        category: { select: { name: true } },
+        payMethod: { select: { id: true, name: true } },
+      },
+    });
+    return res.json({ httpStatus: 'OK', accountHistory });
+  } catch (error) {
+    new Error(error);
+    return res.json({ httpStatus: 'Failed' });
+  }
+});
+
+/**
  * ORM을 위한 조건에 filter option을 만듭니다.
  */
 const generateFilter = (options: any): FilterOption => {
@@ -24,21 +45,6 @@ const generateFilter = (options: any): FilterOption => {
 
   return opt;
 };
-
-/**
- * 필터에 맞는 accountHistory를 반환합니다.
- */
-router.get('/', checkToken(), async (req: any, res) => {
-  try {
-    const opt = generateFilter(req.body);
-
-    const accountHistory = await db.accountHistory.findMany({ where: { ...opt, userId: req.id } });
-    return res.json({ httpStatus: 'OK', accountHistory });
-  } catch (error) {
-    new Error(error);
-    return res.json({ httpStatus: 'Failed' });
-  }
-});
 
 /**
  * AccountHistory 를 만들어 줍니다.


### PR DESCRIPTION
## :bookmark_tabs: 제목

### GET ~/account-history에 category, payMethod 필드 추가

localhost:8080/api/account-history?type=income&expenditureDay=2021-08

<img width="372" alt="스크린샷 2021-08-05 오전 11 21 39" src="https://user-images.githubusercontent.com/19240202/128280805-692aedc9-c0cb-40d8-a436-e3950d72e11b.png">


## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] body 로 받던 데이터 query 로 수정
- [x] category, payMethod 필드 추가

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- X
