### PR TITLE
[Feature/#37] 달력 페이지 API 연동 및 모달 구현

### DIFF
--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -25,10 +25,10 @@ const triggerAfterUserAuthCheck = (accessToken: Token): void => {
 if (getValueOnLocalStorage('refreshToken')) {
   const refresh = getValueOnLocalStorage('refreshToken');
 
-  api.get(`/auth/login?refresh=${refresh}`).then((res) => {
-    const { httpStatus, accessToken } = res.data;
-    if (httpStatus === 'OK') return triggerAfterUserAuthCheck(accessToken);
-  });
+  // api.get(`/auth/login?refresh=${refresh}`).then((res) => {
+  //   const { httpStatus, accessToken } = res.data;
+  //   if (httpStatus === 'OK') return triggerAfterUserAuthCheck(accessToken);
+  // });
 }
 
 /**

--- a/client/src/static/constants.ts
+++ b/client/src/static/constants.ts
@@ -58,6 +58,7 @@ export const COLORS_BY_CATEGORY = {
   life: '#5758BB',
   shopping: '#FFC312',
   traffic: '#006266',
+  income: '#1289A7',
 };
 
 export const NAME_BY_CATEGORY = {

--- a/client/src/static/constants.ts
+++ b/client/src/static/constants.ts
@@ -1,4 +1,16 @@
-import { Account, Calendar, Statistic, CULTURE, ETC, HEALTH, FOOD, TRAFFIC, SHOPPING, LIFE } from './image-urls';
+import {
+  Account,
+  Calendar,
+  Statistic,
+  CULTURE,
+  ETC,
+  HEALTH,
+  FOOD,
+  TRAFFIC,
+  SHOPPING,
+  LIFE,
+  INCOME,
+} from './image-urls';
 
 // Usage : client/src/index.ts
 export const initStoreData = {
@@ -48,6 +60,7 @@ export const PICTOGRAM = {
   life: LIFE,
   shopping: SHOPPING,
   traffic: TRAFFIC,
+  income: INCOME,
 };
 
 export const COLORS_BY_CATEGORY = {
@@ -69,5 +82,6 @@ export const NAME_BY_CATEGORY = {
   life: '생활',
   shopping: '쇼핑/뷰티',
   traffic: '교통',
+  income: '수입',
 };
 export const categoryList = ['문화', '의료/건강', '음식', '교통', '생활', '쇼핑/뷰티', '기타'];

--- a/client/src/static/image-urls.ts
+++ b/client/src/static/image-urls.ts
@@ -18,6 +18,7 @@ export const HEALTH = BASE_URL + 'category' + '/health.svg';
 export const LIFE = BASE_URL + 'category' + '/life.svg';
 export const SHOPPING = BASE_URL + 'category' + '/shopping.svg';
 export const TRAFFIC = BASE_URL + 'category' + '/traffic.svg';
+export const INCOME = BASE_URL + 'category' + '/income.svg';
 
 export const CheckButton = BASE_URL + 'checkbutton.svg';
 export const Option = BASE_URL + 'option.svg';

--- a/client/src/static/image-urls.ts
+++ b/client/src/static/image-urls.ts
@@ -29,3 +29,7 @@ export const TrashCan = BASE_URL + 'trashcan.svg';
 // login
 export const LoginBg = BASE_URL + 'login' + '/login-bg.svg';
 export const GithubIcon = BASE_URL + 'login' + '/github.svg';
+
+// Calendar
+export const ExpenditureIcon = BASE_URL + 'calendar' + '/expenditure.svg';
+export const IncomeIcon = BASE_URL + 'calendar' + '/income.svg';

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -90,11 +90,11 @@ export type CalendarData = {
   dayData: {
     [key: string]: {
       detail: CalendarEssentialData[]; //
+      containCategory: string[];
       dayTotalIncome: number;
       dayTotalExpenditure: number;
     };
   };
   totalIncome: number;
   totalExpenditure: number;
-  containCategory: string[];
 };

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -98,3 +98,17 @@ export type CalendarData = {
   totalIncome: number;
   totalExpenditure: number;
 };
+
+export type CalendarModalData = {
+  date: {
+    year: Year;
+    month: Month;
+    date: Date | string;
+  };
+  dayData: {
+    detail: CalendarEssentialData[]; //
+    containCategory: string[];
+    dayTotalIncome: number;
+    dayTotalExpenditure: number;
+  };
+};

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -64,3 +64,37 @@ export type TargetDateInfos = {
   year: Year;
   month: Month;
 };
+
+export type ServerHistoryData = {
+  id: number;
+  price: number;
+  type: string;
+  expenditureDay: string;
+  userId: number;
+  categoryId: number;
+  payMethodId: number;
+  historyContent: string;
+  category: {
+    id: number;
+    name: string;
+  };
+  payMethod: {
+    id: number;
+    name: string;
+  };
+};
+
+export type CalendarEssentialData = { price: number; category: string; historyContent: string };
+
+export type CalendarData = {
+  dayData: {
+    [key: string]: {
+      detail: CalendarEssentialData[]; //
+      dayTotalIncome: number;
+      dayTotalExpenditure: number;
+    };
+  };
+  totalIncome: number;
+  totalExpenditure: number;
+  containCategory: string[];
+};

--- a/client/src/utils/helper.ts
+++ b/client/src/utils/helper.ts
@@ -1,3 +1,5 @@
+import { Date } from '@src/types';
+
 export const monthText = {
   '1': 'Jan',
   '2': 'Feb',
@@ -34,7 +36,7 @@ export const changeIntoDateFormat = (data: number) => {
   const h = currentDate.getHours();
   const hh = h <= 12 ? h : h - 12;
   const mm = currentDate.getMinutes();
-  return `${m}월 ${d}일, ${hh.toString().padStart(2, '0')}:${mm} ${h < 12 ? 'am' : 'pm'}`;
+  return `${m}월 ${d}일, ${formatDateAsTwoLetters(hh)}:${mm} ${h < 12 ? 'am' : 'pm'}`;
 };
 
 export const createDOMWithSelector = (tag: string, ...selectors: string[]) => {
@@ -85,4 +87,8 @@ export const removeValueOnLocalStorage = (key: string) => {
 
 export const formatDataIntoWon = (data: number) => {
   return new Intl.NumberFormat('kr-KR', { style: 'currency', currency: 'KRW' }).format(data);
+};
+
+export const formatDateAsTwoLetters = (date: Date | number) => {
+  return date.toString().padStart(2, '0');
 };

--- a/client/src/utils/helper.ts
+++ b/client/src/utils/helper.ts
@@ -82,3 +82,7 @@ export const getValueOnLocalStorage = (key: string) => {
 export const removeValueOnLocalStorage = (key: string) => {
   localStorage.removeItem(key);
 };
+
+export const formatDataIntoWon = (data: number) => {
+  return new Intl.NumberFormat('kr-KR', { style: 'currency', currency: 'KRW' }).format(data);
+};

--- a/client/src/utils/helper.ts
+++ b/client/src/utils/helper.ts
@@ -89,6 +89,6 @@ export const formatDataIntoWon = (data: number) => {
   return new Intl.NumberFormat('kr-KR', { style: 'currency', currency: 'KRW' }).format(data);
 };
 
-export const formatDateAsTwoLetters = (date: Date | number) => {
+export const formatDateAsTwoLetters = (date: Date | number | string) => {
   return date.toString().padStart(2, '0');
 };

--- a/client/src/views/page-components/calendar-page/Calendar/Calendar.scss
+++ b/client/src/views/page-components/calendar-page/Calendar/Calendar.scss
@@ -65,9 +65,36 @@
                 }
 
                 &:not(.not-current-month-date){
-                    cursor:pointer;
                     &:hover{
                       filter: drop-shadow(4px 4px 20px rgba(0, 0, 0, 0.25));
+                    }
+                }
+
+                &.contain-data{
+                    cursor:pointer;
+                }
+
+                span{
+                    display:block;
+                    height:18px;
+                }
+
+                .contain-category{
+                    height:fit-content;
+                    width:100%;
+                    margin-top:20px;
+                    padding: 0 5px;
+
+                    display:grid;
+                    grid-template-columns: repeat(4, 1fr);
+                    grid-template-rows: repeat(2, 1fr);
+                    gap:5px;
+
+                    div{
+                        width:18px;
+                        height:18px;
+                        border-radius:50%;
+                        place-self:center;
                     }
                 }
             }
@@ -78,7 +105,7 @@
 @mixin totalMoneyFontStyleMixin {
     font-family: Raleway;
     font-weight: bold;
-    font-size: 25px;
+    font-size: 22px;
 }
 .calendar__total-money{
     display:flex;

--- a/client/src/views/page-components/calendar-page/Calendar/Calendar.scss
+++ b/client/src/views/page-components/calendar-page/Calendar/Calendar.scss
@@ -74,3 +74,32 @@
         }
     }
 }
+
+@mixin totalMoneyFontStyleMixin {
+    font-family: Raleway;
+    font-weight: bold;
+    font-size: 25px;
+}
+.calendar__total-money{
+    display:flex;
+    height:50px;
+    justify-content: flex-end;
+
+    span{
+        @include totalMoneyFontStyleMixin;
+        padding: 15px;
+    }
+
+    .calendar__total-money--expenditure{
+        display:flex;
+        align-items: center;
+        color: #E63950;
+        margin-right:10px;
+    }
+
+    .calendar__total-money--income{
+        display:flex;
+        align-items: center;
+        color: #1289A7;
+    }
+}

--- a/client/src/views/page-components/calendar-page/Calendar/Calendar.ts
+++ b/client/src/views/page-components/calendar-page/Calendar/Calendar.ts
@@ -50,6 +50,7 @@ export default class CalendarView {
    */
   handleModal(e: Event, { dayObj, calendarData }: CalendarView) {
     if (!(e.target instanceof HTMLElement)) return;
+    if (e.target.closest('.content__calendar__modal')) return;
     if (!e.target.closest('.contain-data')) return handleEvent.fire('opencalendarmodal', { command: 'close' });
 
     const target = e.target.closest('.contain-data') as HTMLElement;

--- a/client/src/views/page-components/calendar-page/Calendar/Calendar.ts
+++ b/client/src/views/page-components/calendar-page/Calendar/Calendar.ts
@@ -1,3 +1,4 @@
+import { COLORS_BY_CATEGORY } from '@src/static/constants';
 import { ExpenditureIcon, IncomeIcon } from '@src/static/image-urls';
 import {
   CalendarData,
@@ -11,7 +12,7 @@ import {
   TargetDateInfos,
   Year,
 } from '@src/types';
-import { createDOMWithSelector, formatDataIntoWon } from '@src/utils/helper';
+import { createDOMWithSelector, formatDataIntoWon, formatDateAsTwoLetters } from '@src/utils/helper';
 
 import './Calendar.scss';
 
@@ -109,24 +110,55 @@ export default class CalendarView {
    * 배열을 순회하며,
    * tr 태그에 해당하는 weekDOM을 생성합니다.
    * ex) <tr>
-   *        <td>1</td>
-   *        <td>2</td>
+   *        <td><span>1</span></td>
+   *        <td><span>2</span></td>
    *        ...
    *     </tr>
+   *
+   * 만약, 해당 일에 해당하는 calendarData가 있을 경우,
+   * 색깔을 표시하기 위해 DOM을 생성해서 넣어줍니다.
    */
   getWeekDOM(week: DayInfos[]): HTMLText {
     const $tr = createDOMWithSelector('tr');
 
     week.forEach(({ day, isCurrentMonthDate }) => {
       const $td = createDOMWithSelector('td');
-
       if (!isCurrentMonthDate) $td.classList.add('not-current-month-date');
-      $td.innerText = `${day}`;
+
+      const $span = createDOMWithSelector('span');
+      $span.innerText = `${day}`;
+      $td.appendChild($span);
+
+      if (isCurrentMonthDate) {
+        const { year, month } = this.dayObj;
+        const dayFormat = `${year}-${formatDateAsTwoLetters(month)}-${formatDateAsTwoLetters(day)}`;
+
+        if (dayFormat in this.calendarData.dayData) {
+          $td.classList.add('contain-data');
+
+          const $containCategory = createDOMWithSelector('div', '.contain-category');
+          const categoryColorDOMs = this.getCategoryColorDOMs(dayFormat);
+
+          $containCategory.innerHTML = categoryColorDOMs;
+          $td.appendChild($containCategory);
+        }
+      }
+
       $tr.appendChild($td);
     });
 
     return $tr.outerHTML;
   }
+
+  /**
+   * 데이터에서 dayFormat 키에 해당하는 category를 가져와서,
+   * DOM으로 변경한 후 반환합니다.
+   */
+  getCategoryColorDOMs = (dayFormat: string): HTMLText => {
+    return this.calendarData.dayData[dayFormat].containCategory
+      .map((cat) => `<div class='contain-category__color' style='background-color:${COLORS_BY_CATEGORY[cat]}'></div>`)
+      .join('');
+  };
 
   /**
    * 달력을 일주일 단위로 분할합니다.

--- a/client/src/views/page-components/calendar-page/Calendar/Calendar.ts
+++ b/client/src/views/page-components/calendar-page/Calendar/Calendar.ts
@@ -10,10 +10,11 @@ export default class CalendarView {
   $tbody: HTMLElement;
   dayObj: { year: Year; month: Month };
 
-  constructor({ parent, currentYear, currentMonth }) {
+  constructor({ parent, currentYear, currentMonth, currentCalendarData }) {
     this.$calendarTable = createDOMWithSelector('table', '.calendar__table');
     this.dayObj = { year: currentYear, month: currentMonth };
 
+    console.log(currentCalendarData);
     parent.appendChild(this.$calendarTable);
     this.render();
   }

--- a/client/src/views/page-components/calendar-page/CalendarDetailInfoModal/CalendarDetailInfoModal.ts
+++ b/client/src/views/page-components/calendar-page/CalendarDetailInfoModal/CalendarDetailInfoModal.ts
@@ -1,0 +1,25 @@
+import { CalendarEssentialData } from '@src/types';
+import handleEvent from '@src/utils/handleEvent';
+import './CalendarDetailInfoModal.scss';
+
+export default class CalendarDetailInfoModal {
+  isModalOpened: false;
+  data: CalendarEssentialData;
+  posX: number;
+  posY: number;
+
+  constructor() {
+    handleEvent.subscribe('opencalendarmodal', (e: CustomEvent) => {
+      if (!this.isModalOpened && e.detail.command === 'close') return;
+
+      if (e.detail.command === 'open') {
+        this.data = e.detail.data.dayData;
+        this.render();
+      }
+    });
+  }
+
+  render() {
+    console.log(this.data);
+  }
+}

--- a/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.scss
+++ b/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.scss
@@ -1,0 +1,58 @@
+@mixin calendarModalFontMixin {
+    font-family: Raleway;
+    font-weight: bold;
+}
+
+.content__calendar__modal{
+    position: absolute;
+    width: 233px;
+    height: 251px;
+    left: 572px;
+    top: 126px;
+    padding: 15px 20px;
+    
+    background: #FFFFFF;
+    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
+    border-radius: 10px;
+
+    .modal__title{
+        @include calendarModalFontMixin;
+        font-size: 16px;
+
+        color: var(--font-color);
+    }
+
+    .modal__total-history{
+        display:flex;
+        align-items:center;
+        width:100%;
+        height:20px;
+        margin-top:15px;
+        
+        div {
+            display:flex;
+            align-items:center;
+            width:50%;
+
+            img {
+                height:20px;
+            }
+
+            span {
+                @include calendarModalFontMixin;
+                height:fit-content;
+                line-height:7px;
+                margin-left:7px;
+                font-size:12px;
+            }
+
+            &.modal__total-history--expenditure{
+                color:#E63950;
+            }
+
+            &.modal__total-history--income{
+                color:#1289A7;
+            }
+        }        
+    }
+}

--- a/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.scss
+++ b/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.scss
@@ -3,6 +3,12 @@
     font-weight: bold;
 }
 
+@mixin controllTextOverflowMixin{
+    overflow-x:hidden;
+    white-space:nowrap;
+    text-overflow:ellipsis;
+}
+
 @mixin modalAnimationAttribute{
     opacity:0;
     z-index:-1;
@@ -90,6 +96,12 @@
                 @include calendarModalFontMixin;
                 font-size:12px;
                 align-self:center;
+                
+                &:not(:last-child){
+                    overflow:hidden;
+                    white-space:nowrap;
+                    text-overflow:ellipsis;
+                }
 
                 &:last-child{
                     text-align:right;

--- a/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.scss
+++ b/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.scss
@@ -6,15 +6,13 @@
 @mixin modalAnimationAttribute{
     opacity:0;
     z-index:-1;
-    // transform:scale(0);
 
     &.open{
         opacity:1;
         z-index:1;
-        // transform:scale(100%);
     }
 
-    transition:all .3s ease-in-out;
+    transition:all .2s ease;
 }
 
 .content__calendar__modal{
@@ -23,8 +21,6 @@
     position: absolute;
     width: 233px;
     height: 251px;
-    left: 572px;
-    top: 126px;
     padding: 15px 20px;
     
     background: #FFFFFF;
@@ -62,6 +58,8 @@
                 font-size:12px;
             }
 
+            
+
             &.modal__total-history--expenditure{
                 color:#E63950;
             }
@@ -92,6 +90,10 @@
                 @include calendarModalFontMixin;
                 font-size:12px;
                 align-self:center;
+
+                &:last-child{
+                    text-align:right;
+                }
             }
         }
 

--- a/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.scss
+++ b/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.scss
@@ -3,7 +3,23 @@
     font-weight: bold;
 }
 
+@mixin modalAnimationAttribute{
+    opacity:0;
+    z-index:-1;
+    // transform:scale(0);
+
+    &.open{
+        opacity:1;
+        z-index:1;
+        // transform:scale(100%);
+    }
+
+    transition:all .3s ease-in-out;
+}
+
 .content__calendar__modal{
+    @include modalAnimationAttribute;
+
     position: absolute;
     width: 233px;
     height: 251px;
@@ -17,7 +33,7 @@
 
     .modal__title{
         @include calendarModalFontMixin;
-        font-size: 16px;
+        font-size: 14px;
 
         color: var(--font-color);
     }
@@ -27,7 +43,7 @@
         align-items:center;
         width:100%;
         height:20px;
-        margin-top:15px;
+        margin-top:17px;
         
         div {
             display:flex;
@@ -54,5 +70,37 @@
                 color:#1289A7;
             }
         }        
+    }
+
+    .modal__detail-history{
+        overflow-y:scroll;
+        width:100%;
+        height:calc(100% - 74px);
+        margin-top:17px;
+
+        .detail-history{
+            display:grid;
+            grid-template-columns: 1fr 4fr 2fr;
+            height:30px;
+            gap:12px;
+
+            img {
+                width:28px;
+            }
+
+            span{
+                @include calendarModalFontMixin;
+                font-size:12px;
+                align-self:center;
+            }
+        }
+
+        .detail-history:not(:last-child){
+            margin-bottom:15px;
+        }
+
+        &::-webkit-scrollbar{
+            display:none;
+        }
     }
 }

--- a/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.ts
+++ b/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.ts
@@ -1,30 +1,56 @@
-import { CalendarEssentialData } from '@src/types';
+import { ExpenditureIcon, IncomeIcon } from '@src/static/image-urls';
+import { CalendarModalData } from '@src/types';
 import handleEvent from '@src/utils/handleEvent';
-import { createDOMWithSelector } from '@src/utils/helper';
+import { createDOMWithSelector, formatDataIntoWon } from '@src/utils/helper';
 
 import './CalendarModal.scss';
 
 export default class CalendarModal {
   $CalendarModal: HTMLElement;
+  data: CalendarModalData;
   isModalOpened: false;
-  data: CalendarEssentialData;
   posX: number;
   posY: number;
 
   constructor({ parent }) {
-    this.$CalendarModal = createDOMWithSelector('div', '.content__calendar__modal');
+    this.$CalendarModal = createDOMWithSelector('aside', '.content__calendar__modal');
+    parent.appendChild(this.$CalendarModal);
 
     handleEvent.subscribe('opencalendarmodal', (e: CustomEvent) => {
       if (!this.isModalOpened && e.detail.command === 'close') return;
 
       if (e.detail.command === 'open') {
-        this.data = e.detail.data.dayData;
+        this.data = e.detail.data;
         this.render();
       }
     });
   }
 
   render() {
-    console.log(this.data);
+    const { date: dateData, dayData } = this.data;
+    const { date, month, year } = dateData;
+    const { detail, dayTotalExpenditure, dayTotalIncome } = dayData;
+
+    console.log('date, month, year: ', date, month, year);
+    this.$CalendarModal.innerHTML = `
+      <h2 class='modal__title'>${year}년 ${month}월 ${date}일</h2>
+      <div class='modal__total-history'>${this.getTotalHistoryDOM(dayTotalExpenditure, dayTotalIncome)}</div>
+    `;
+  }
+
+  /**
+   * 총 수입, 지출 내역을 모달에 표시합니다.
+   */
+  getTotalHistoryDOM(expenditure: number, income: number) {
+    return `
+      <div class='modal__total-history--expenditure'>
+        <img src=${ExpenditureIcon} alt='expenditure'>
+        <span>${formatDataIntoWon(expenditure)}</span>
+      </div>
+      <div class='modal__total-history--income'>
+        <img src=${IncomeIcon} alt='income'>
+        <span>${formatDataIntoWon(income)}</span>
+      </div>
+    `;
   }
 }

--- a/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.ts
+++ b/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.ts
@@ -20,7 +20,11 @@ export default class CalendarModal {
     handleEvent.subscribe('opencalendarmodal', (e: CustomEvent) => {
       if (!this.isModalOpened && e.detail.command === 'close') return;
       if (e.detail.command === 'close') return this.closeModal();
-      if (e.detail.command === 'open') this.openModal(e.detail.data);
+      if (e.detail.command === 'open') {
+        this.closeModal();
+        this.setModalPosition(e);
+        this.openModal(e.detail.data);
+      }
     });
   }
 
@@ -43,9 +47,22 @@ export default class CalendarModal {
     this.render();
   }
 
+  /**
+   * 모달의 위치를 정해줍니다.
+   */
+  setModalPosition(e: CustomEvent) {
+    const { top, left } = e.detail.pos;
+    const offsetX = -40;
+    const offsetY = 220;
+
+    this.$CalendarModal.setAttribute('style', `top:${top - offsetY}px;left:${left - offsetX}px`);
+  }
+
   render() {
     const { date: dateData, dayData } = this.data;
     const { date, month, year } = dateData;
+
+    if (!dayData) return;
     const { detail, dayTotalExpenditure, dayTotalIncome } = dayData;
 
     this.$CalendarModal.innerHTML = `

--- a/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.ts
+++ b/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.ts
@@ -1,14 +1,19 @@
 import { CalendarEssentialData } from '@src/types';
 import handleEvent from '@src/utils/handleEvent';
-import './CalendarDetailInfoModal.scss';
+import { createDOMWithSelector } from '@src/utils/helper';
 
-export default class CalendarDetailInfoModal {
+import './CalendarModal.scss';
+
+export default class CalendarModal {
+  $CalendarModal: HTMLElement;
   isModalOpened: false;
   data: CalendarEssentialData;
   posX: number;
   posY: number;
 
-  constructor() {
+  constructor({ parent }) {
+    this.$CalendarModal = createDOMWithSelector('div', '.content__calendar__modal');
+
     handleEvent.subscribe('opencalendarmodal', (e: CustomEvent) => {
       if (!this.isModalOpened && e.detail.command === 'close') return;
 

--- a/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.ts
+++ b/client/src/views/page-components/calendar-page/CalendarModal/CalendarModal.ts
@@ -1,5 +1,6 @@
+import { COLORS_BY_CATEGORY, PICTOGRAM } from '@src/static/constants';
 import { ExpenditureIcon, IncomeIcon } from '@src/static/image-urls';
-import { CalendarModalData } from '@src/types';
+import { CalendarEssentialData, CalendarModalData } from '@src/types';
 import handleEvent from '@src/utils/handleEvent';
 import { createDOMWithSelector, formatDataIntoWon } from '@src/utils/helper';
 
@@ -8,7 +9,7 @@ import './CalendarModal.scss';
 export default class CalendarModal {
   $CalendarModal: HTMLElement;
   data: CalendarModalData;
-  isModalOpened: false;
+  isModalOpened: Boolean;
   posX: number;
   posY: number;
 
@@ -18,12 +19,28 @@ export default class CalendarModal {
 
     handleEvent.subscribe('opencalendarmodal', (e: CustomEvent) => {
       if (!this.isModalOpened && e.detail.command === 'close') return;
-
-      if (e.detail.command === 'open') {
-        this.data = e.detail.data;
-        this.render();
-      }
+      if (e.detail.command === 'close') return this.closeModal();
+      if (e.detail.command === 'open') this.openModal(e.detail.data);
     });
+  }
+
+  /**
+   * 모달을 닫을 경우 호출합니다.
+   * isModalOpened 상태를 false로 만듭니다.
+   */
+  closeModal() {
+    this.isModalOpened = false;
+    this.$CalendarModal.classList.remove('open');
+  }
+
+  /**
+   * 모달을 열게 될 경우 호출합니다.
+   */
+  openModal(data: any) {
+    this.isModalOpened = true;
+    this.data = data;
+    this.$CalendarModal.classList.add('open');
+    this.render();
   }
 
   render() {
@@ -31,11 +48,45 @@ export default class CalendarModal {
     const { date, month, year } = dateData;
     const { detail, dayTotalExpenditure, dayTotalIncome } = dayData;
 
-    console.log('date, month, year: ', date, month, year);
     this.$CalendarModal.innerHTML = `
       <h2 class='modal__title'>${year}년 ${month}월 ${date}일</h2>
       <div class='modal__total-history'>${this.getTotalHistoryDOM(dayTotalExpenditure, dayTotalIncome)}</div>
+      <div class='modal__detail-history'>${this.getDetailHistoryDOM(detail)}</div>
     `;
+  }
+
+  /**
+   * 결제 내역에 대해 detailHistory DOM 요소를 생성하여 반환합니다.
+   */
+  getDetailHistoryDOM(detail: CalendarEssentialData[]) {
+    return detail.reduce((acc, d) => [...acc, this.createDetailHistory(d)], []).join('');
+  }
+
+  /**
+   * detailHistory DOM을 생성합니다.
+   * 모달 내의 수입, 지출 내역에 해당하는 DOM 으로
+   * category img, history content, price를 가집니다.
+   */
+  createDetailHistory(data: CalendarEssentialData) {
+    const { price, category, historyContent } = data;
+
+    const $detailHistory = createDOMWithSelector('div', '.detail-history');
+    const $img = createDOMWithSelector('img');
+    $img.setAttribute('src', PICTOGRAM[category]);
+
+    const $content = createDOMWithSelector('span');
+    $content.setAttribute('style', `color:${COLORS_BY_CATEGORY[category]}`);
+    $content.innerText = historyContent;
+
+    const $price = createDOMWithSelector('span');
+    $price.setAttribute('style', `color:${category === 'income' ? '#1289A7' : '#E63950'}`);
+    $price.innerText = formatDataIntoWon(price);
+
+    $detailHistory.appendChild($img);
+    $detailHistory.appendChild($content);
+    $detailHistory.appendChild($price);
+
+    return $detailHistory.outerHTML;
   }
 
   /**

--- a/client/src/views/page-components/calendar-page/index.ts
+++ b/client/src/views/page-components/calendar-page/index.ts
@@ -1,21 +1,33 @@
 import { Month, Year } from '@src/types';
 import handleEvent from '@src/utils/handleEvent';
 import { $ } from '@src/utils/helper';
-import CalendarView from './Calendar/Calendar';
 
 import './index.scss';
+import CalendarView from './Calendar/Calendar';
+import { api } from '@src/models/api';
 
 export default class CalendarPageView {
   currentYear: Year;
   currentMonth: Month;
+  currentCalendarData: [];
 
   constructor() {
     handleEvent.subscribe('storeupdated', (e: CustomEvent) => {
-      const { path, month, year } = e.detail.state;
+      const { path, month, year, accessToken } = e.detail.state;
       if (path !== '/calendar') return;
       this.currentYear = year;
       this.currentMonth = month;
-      this.render();
+
+      const fetchCalendarDataURL = `/account-history?type=income&expenditureDay=${year}-${month
+        .toString()
+        .padStart(2, '0')}`;
+
+      api.get(fetchCalendarDataURL, accessToken).then((res) => {
+        if (res.success) {
+          this.currentCalendarData = res.data.accountHistory;
+          this.render();
+        }
+      });
     });
   }
 
@@ -26,6 +38,7 @@ export default class CalendarPageView {
       parent: $('.content__calendar'),
       currentYear: this.currentYear,
       currentMonth: this.currentMonth,
+      currentCalendarData: this.currentCalendarData,
     });
   }
 }

--- a/client/src/views/page-components/calendar-page/index.ts
+++ b/client/src/views/page-components/calendar-page/index.ts
@@ -5,6 +5,7 @@ import { $ } from '@src/utils/helper';
 import './index.scss';
 import CalendarView from './Calendar/Calendar';
 import { api } from '@src/models/api';
+import CalendarDetailInfoModal from './CalendarDetailInfoModal/CalendarDetailInfoModal';
 
 export default class CalendarPageView {
   currentYear: Year;
@@ -38,5 +39,6 @@ export default class CalendarPageView {
       currentMonth: this.currentMonth,
       currentCalendarData: this.currentCalendarData,
     });
+    new CalendarDetailInfoModal();
   }
 }

--- a/client/src/views/page-components/calendar-page/index.ts
+++ b/client/src/views/page-components/calendar-page/index.ts
@@ -1,11 +1,11 @@
+import { api } from '@src/models/api';
 import { Month, Year } from '@src/types';
 import handleEvent from '@src/utils/handleEvent';
 import { $ } from '@src/utils/helper';
 
 import './index.scss';
 import CalendarView from './Calendar/Calendar';
-import { api } from '@src/models/api';
-import CalendarDetailInfoModal from './CalendarDetailInfoModal/CalendarDetailInfoModal';
+import CalendarModal from './CalendarModal/CalendarModal';
 
 export default class CalendarPageView {
   currentYear: Year;
@@ -39,6 +39,6 @@ export default class CalendarPageView {
       currentMonth: this.currentMonth,
       currentCalendarData: this.currentCalendarData,
     });
-    new CalendarDetailInfoModal();
+    new CalendarModal({ parent: $('.content__calendar') });
   }
 }

--- a/client/src/views/page-components/calendar-page/index.ts
+++ b/client/src/views/page-components/calendar-page/index.ts
@@ -18,9 +18,7 @@ export default class CalendarPageView {
       this.currentYear = year;
       this.currentMonth = month;
 
-      const fetchCalendarDataURL = `/account-history?type=income&expenditureDay=${year}-${month
-        .toString()
-        .padStart(2, '0')}`;
+      const fetchCalendarDataURL = `/account-history?expenditureDay=${year}-${month.toString().padStart(2, '0')}`;
 
       api.get(fetchCalendarDataURL, accessToken).then((res) => {
         if (res.success) {


### PR DESCRIPTION
## :bookmark_tabs: 제목

### 달력 페이지 API 연동 및 모달 구현


https://user-images.githubusercontent.com/19240202/128361359-c6610134-c0a3-4537-befa-7f407fa30d68.mov


## :heavy_check_mark: 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?

## :speech_balloon: 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Close #37 

## :construction: PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 코드 리뷰 하기 어려운 상황일 것으로 생각됩니다 (시간이 없어서 ㅜ). 코드 리뷰는 하지 않아도 되지만, PR 을 받아 구현한 코드가 지호님 환경에서도 잘 돌아가는지 확인을 해주시면 감사하겠습니다.
- 다른 분들이 캘린더 데이터를 확인하기 위해 데이터를 추가해야 할 것 같습니다. 이를 위해, 데모데이때는 사용자가 계정을 만들면 디폴트 데이터를 추가하는 쿼리문을 넣어놓는 것도 좋을 것 같습니다.
